### PR TITLE
make the top-right menu dynamic and add several icons (e.g. profile, …)

### DIFF
--- a/src/lib/Dashboard/definition.ts
+++ b/src/lib/Dashboard/definition.ts
@@ -1,6 +1,6 @@
 import { get, writable, type Writable } from 'svelte/store';
 
-import type { MenuLink } from '$lib/Menu/MenuLinks';
+import type { itemMenuLinks, MenuLink } from '$lib/Menu/MenuLinks';
 import type { Dictionaries } from '$lib/admin_i18n';
 import type { CrudDefinition } from '$lib/Crud/definition';
 import { type AdminConfig, emptyAdminConfig } from '$lib/config/adminConfig';
@@ -9,7 +9,7 @@ import { type AdminConfig, emptyAdminConfig } from '$lib/config/adminConfig';
 export type DashboardStores = {
 	sideMenu: Writable<Array<MenuLink>>;
 	topLeftMenu: Writable<Array<MenuLink>>;
-	topRightMenu: Writable<Array<MenuLink>>;
+	topRightMenu: Writable<Array<itemMenuLinks>>;
 };
 
 /**
@@ -20,7 +20,7 @@ export type DashboardDefinitionOptions = {
 	rootUrl?: string;
 	sideMenu?: Array<MenuLink>;
 	topLeftMenu?: Array<MenuLink>;
-	topRightMenu?: Array<MenuLink>;
+	topRightMenu?: Array<itemMenuLinks>;
 	localeDictionaries?: Dictionaries;
 };
 
@@ -74,7 +74,7 @@ export class DashboardDefinition {
 	}
 
 	/** @deprecated Use builtin Dashboard stores instead */
-	get topRightMenu(): Array<MenuLink> {
+	get topRightMenu(): Array<itemMenuLinks> {
 		return get(this.stores.topRightMenu);
 	}
 

--- a/src/lib/Menu/MenuLinks.ts
+++ b/src/lib/Menu/MenuLinks.ts
@@ -1,8 +1,15 @@
 import {type Action, type ActionIcon, DefaultAction} from '$lib/actions';
 import type { Optional } from '$lib/genericTypes';
+import type { CarbonIcon } from 'carbon-icons-svelte/lib/CarbonIcon';
 
 /** */
 export type MenuLink = Action;
+
+/** */
+export type itemMenuLinks = {
+	icon?: CarbonIcon|null,
+	links: Array<MenuLink>
+}
 
 /** */
 export class Submenu extends DefaultAction {

--- a/src/lib/themes/carbon/Layout/AdminLayout.svelte
+++ b/src/lib/themes/carbon/Layout/AdminLayout.svelte
@@ -7,7 +7,7 @@
 
 	import TopMenu from '../Menu/TopMenu.svelte';
 	import SideMenu from '../Menu/SideMenu.svelte';
-	import type { MenuLink } from '$lib/Menu/MenuLinks';
+	import type { itemMenuLinks, MenuLink } from '$lib/Menu/MenuLinks';
 
 	import { type Dictionaries, initLocale } from '$lib/admin_i18n';
 	import type { AdminConfig } from '$lib/config/adminConfig';
@@ -21,7 +21,7 @@
 
 	export let side_menu_links: Array<MenuLink> = [];
 	export let top_left_menu_links: Array<MenuLink> = [];
-	export let top_right_menu_links: Array<MenuLink> = [];
+	export let top_right_menu_links: Array<itemMenuLinks> = [];
 
 	initLocale(adminConfig?.defaultLocale || getLocaleFromNavigator() || 'en', translations);
 

--- a/src/lib/themes/carbon/Menu/TopMenu.svelte
+++ b/src/lib/themes/carbon/Menu/TopMenu.svelte
@@ -4,11 +4,11 @@
 
 	import TopLeftMenu from '$lib/themes/carbon/Menu/TopLeftMenu.svelte';
 	import TopRightMenu from '$lib/themes/carbon/Menu/TopRightMenu.svelte';
-	import type { MenuLink } from '$lib/Menu/MenuLinks';
+	import type { itemMenuLinks, MenuLink } from '$lib/Menu/MenuLinks';
 	import { type AdminConfig, emptyAdminConfig } from '$lib/config/adminConfig';
 
 	export let left_links: Array<MenuLink> = [];
-	export let right_links: Array<MenuLink> = [];
+	export let right_links: Array<itemMenuLinks> = [];
 
 	export let adminConfig: AdminConfig = emptyAdminConfig();
 
@@ -26,6 +26,6 @@
 
 	<TopLeftMenu links={left_links} />
 	{#if right_links.length}
-		<TopRightMenu links={right_links} />
+		<TopRightMenu items={right_links} />
 	{/if}
 </Header>

--- a/src/lib/themes/carbon/Menu/TopRightMenu.svelte
+++ b/src/lib/themes/carbon/Menu/TopRightMenu.svelte
@@ -8,56 +8,70 @@
 
 	import Link from 'carbon-icons-svelte/lib/Link.svelte';
 
-	import { Divider, type MenuLink, Submenu } from '$lib/Menu/MenuLinks';
+	import { Divider, type itemMenuLinks, Submenu } from '$lib/Menu/MenuLinks';
 	import { CallbackAction, UrlAction } from '$lib/actions';
+	import { Help, Switcher } from 'carbon-icons-svelte';
 
-	export let links: Array<MenuLink> = [];
+	export let items: Array<itemMenuLinks> = [];
+	console.log(items);
+	for (let i = 0; i < items.length; i++) {
+		// Ajoutez un nouvel attribut à chaque objet
+		items[i].isOpen = false;
+	}
+
 </script>
 
 <HeaderUtilities>
-	<HeaderAction>
-		<HeaderPanelLinks>
-			{#each links as link}
-				{#if link instanceof Submenu}
-					<HeaderPanelDivider>{link.label ? $_(link.label) : ''}</HeaderPanelDivider>
-					{#each link.links as subLink}
-						{#if subLink instanceof Divider}
-							<br />
-						{:else if subLink instanceof UrlAction}
-							<HeaderPanelLink href={subLink.url()} {...link.options.htmlAttributes}>
-								{subLink.icon ? subLink.icon : ''}
-								{subLink.label ? $_(subLink.label) : ''}
-							</HeaderPanelLink>
-						{:else if subLink instanceof CallbackAction}
-							<HeaderPanelLink on:click={() => subLink.call()} {...link.options.htmlAttributes}>
-								{subLink.icon ? subLink.icon : ''}
-								{subLink.label ? $_(subLink.label) : ''}
-							</HeaderPanelLink>
-						{:else}
-							<HeaderPanelLink icon={subLink.icon || Link} {...link.options.htmlAttributes}>
-								{subLink.label ? $_(subLink.label) : ''}
-							</HeaderPanelLink>
-						{/if}
-					{/each}
-				{:else if link instanceof Divider}
-					<HeaderPanelDivider>{link.label ? $_(link.label) : ''}</HeaderPanelDivider>
-				{:else if link instanceof UrlAction}
-					<HeaderPanelLink href={link.url()} {...link.options.htmlAttributes}>
-						{link.icon ? link.icon : ''}
-						{link.label ? $_(link.label) : ''}
-					</HeaderPanelLink>
-				{:else if link instanceof CallbackAction}
-					<HeaderPanelLink on:click={() => link.call()} {...link.options.htmlAttributes}>
-						{link.icon ? link.icon : ''}
-						{link.label ? $_(link.label) : ''}
-					</HeaderPanelLink>
-				{:else}
-					<HeaderPanelLink {...link.options.htmlAttributes}>
-						{link.icon ? link.icon : ''}
-						{link.label ? $_(link.label) : ''}
-					</HeaderPanelLink>
-				{/if}
-			{/each}
-		</HeaderPanelLinks>
-	</HeaderAction>
+
+	{#each items as item}
+		<HeaderAction
+			icon={item.icon ?? Switcher}
+			closeIcon={item.icon ?? Switcher}
+			bind:isOpen={item.isOpen}
+		>
+			<HeaderPanelLinks>
+				{#each item.links as link}
+					{#if link instanceof Submenu}
+						<HeaderPanelDivider>{link.label ? $_(link.label) : ''}</HeaderPanelDivider>
+						{#each link.links as subLink}
+							{#if subLink instanceof Divider}
+								<br />
+							{:else if subLink instanceof UrlAction}
+								<HeaderPanelLink href={subLink.url()} {...link.options.htmlAttributes}>
+									{subLink.icon ? subLink.icon : ''}
+									{subLink.label ? $_(subLink.label) : ''}
+								</HeaderPanelLink>
+							{:else if subLink instanceof CallbackAction}
+								<HeaderPanelLink on:click={() => subLink.call()} {...link.options.htmlAttributes}>
+									{subLink.icon ? subLink.icon : ''}
+									{subLink.label ? $_(subLink.label) : ''}
+								</HeaderPanelLink>
+							{:else}
+								<HeaderPanelLink icon={subLink.icon || Link} {...link.options.htmlAttributes}>
+									{subLink.label ? $_(subLink.label) : ''}
+								</HeaderPanelLink>
+							{/if}
+						{/each}
+					{:else if link instanceof Divider}
+						<HeaderPanelDivider>{link.label ? $_(link.label) : ''}</HeaderPanelDivider>
+					{:else if link instanceof UrlAction}
+						<HeaderPanelLink href={link.url()} {...link.options.htmlAttributes}>
+							{link.icon ? link.icon : ''}
+							{link.label ? $_(link.label) : ''}
+						</HeaderPanelLink>
+					{:else if link instanceof CallbackAction}
+						<HeaderPanelLink on:click={() => link.call()} {...link.options.htmlAttributes}>
+							{link.icon ? link.icon : ''}
+							{link.label ? $_(link.label) : ''}
+						</HeaderPanelLink>
+					{:else}
+						<HeaderPanelLink {...link.options.htmlAttributes}>
+							{link.icon ? link.icon : ''}
+							{link.label ? $_(link.label) : ''}
+						</HeaderPanelLink>
+					{/if}
+				{/each}
+			</HeaderPanelLinks>
+		</HeaderAction>
+	{/each}
 </HeaderUtilities>

--- a/src/lib/themes/carbon/Menu/TopRightMenu.svelte
+++ b/src/lib/themes/carbon/Menu/TopRightMenu.svelte
@@ -13,7 +13,6 @@
 	import { Help, Switcher } from 'carbon-icons-svelte';
 
 	export let items: Array<itemMenuLinks> = [];
-	console.log(items);
 	for (let i = 0; i < items.length; i++) {
 		items[i].isOpen = false;
 	}

--- a/src/lib/themes/carbon/Menu/TopRightMenu.svelte
+++ b/src/lib/themes/carbon/Menu/TopRightMenu.svelte
@@ -15,7 +15,6 @@
 	export let items: Array<itemMenuLinks> = [];
 	console.log(items);
 	for (let i = 0; i < items.length; i++) {
-		// Ajoutez un nouvel attribut à chaque objet
 		items[i].isOpen = false;
 	}
 

--- a/src/testApp/Dashboard.ts
+++ b/src/testApp/Dashboard.ts
@@ -7,6 +7,7 @@ import { DashboardDefinition, CallbackAction, UrlAction, Submenu, themes } from 
 import fr from './translations/fr';
 import { bookCrud } from './BookCrud';
 import { testCrud } from './TestCrud';
+import { Help, UserAvatarFilledAlt } from 'carbon-icons-svelte';
 
 let newLinkIndex = 1;
 
@@ -34,12 +35,27 @@ export const dashboard = new DashboardDefinition({
 	],
 	topLeftMenu: [new UrlAction('Docs', '/docs', Document, { htmlAttributes: { rel: 'external' } })],
 	topRightMenu: [
-		new CallbackAction('Add a new link to the menu', null, () => {
-			dashboard.stores.topRightMenu.update((links) => [
-				...links,
-				new UrlAction('Custom link' + newLinkIndex++, '#')
-			]);
-		})
+		{
+			icon: Help,
+			links: [
+				new CallbackAction('Add a new link to the menu', null, () => {})
+			]
+		},
+		{
+			icon: UserAvatarFilledAlt,
+			links: [
+				new CallbackAction('Add a new link to the menu', null, () => {}),
+				new CallbackAction('Add a new link to the menu', null, () => {}),
+			]
+		},
+		{
+			icon: null,
+			links: [
+				new CallbackAction('Add a new link to the menu', null, () => {}),
+				new CallbackAction('Add a new link to the menu', null, () => {}),
+				new CallbackAction('Add a new link to the menu', null, () => {})
+			]
+		}
 	],
 	localeDictionaries: {
 		fr: fr


### PR DESCRIPTION
The top-right menu works differently, so you can make several sub-menus with different icons. 

Change of type for topRightMenu to itemMenuLinks with two properties: icon and links (the basic type).

Added a loop in the top-right menu layout to add a HeaderAction for each occurrences with an icon and links defined in the dashboardDefinition.